### PR TITLE
docs: add LinkedIn Event Attendees source and Export to Grid tutorial

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -51,6 +51,7 @@
                   "ingredients/source-post-interactors",
                   "ingredients/source-conversational-intent",
                   "ingredients/source-linkedin-jobs",
+                  "ingredients/source-linkedin-event-attendees",
                   "ingredients/source-competitor-customers"
                 ]
               },
@@ -140,6 +141,7 @@
                   "ingredients/tutorial-column-templates",
                   "ingredients/tutorial-integrations",
                   "ingredients/workbooks",
+                  "ingredients/tutorial-export-to-grid",
                   "ingredients/source-scheduling",
                   "ingredients/rate_limits",
                   "ingredients/rollover-policy",

--- a/ingredients/source-linkedin-event-attendees.mdx
+++ b/ingredients/source-linkedin-event-attendees.mdx
@@ -1,0 +1,82 @@
+---
+title: "Finding LinkedIn Event Attendees"
+description: "Use your connected LinkedIn account to scrape the attendee list of a LinkedIn Event, then enrich those attendees for a warm, high-intent outbound list. Available on demand for enterprise customers."
+---
+
+### Overview
+
+<iframe width="100%" style={{aspectRatio: "16/9"}} src="https://www.youtube.com/embed/3S8oKv-RQpE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+Virtual events have been picking up a lot of speed in GTM, and a large share of them now happen natively on LinkedIn. The people who attend one of these events are a strong list-building source: they're already aware of the space, aware of the domain, and there's usually a reason they showed up (they're looking for a solution). Combined with your own ICP scoring logic, event attendees can turn into a genuinely good list to reach out to.
+
+> **Note:** This feature is available **on demand, for enterprise customers only**. Reach out to the Bitscale team if you'd like it enabled for your workspace.
+
+---
+
+### **When to Use**
+
+- A relevant event in your space is happening (or has happened) natively on LinkedIn, and you want a list of people who attended.
+- You want a warm starting point for outbound, since attendees are self-selected as interested in the topic.
+- You plan to layer your own ICP scoring on top (title, industry, company) rather than treat every attendee as equally qualified.
+
+---
+
+### **Prerequisites**
+
+- A **LinkedIn account connected** to Bitscale. This does **not** need to be Sales Navigator, a regular LinkedIn login is enough, since Bitscale just needs an authenticated LinkedIn instance to scrape the event.
+- You (or the connected account) must **also be attending the event yourself**. Attendee scraping runs through your own LinkedIn instance, so you need to be part of the event to pull its attendee list.
+
+---
+
+### **Setting Up the LinkedIn Connection**
+
+1. In Bitscale, go to **Integrations → Add Integration**.
+2. Search for **LinkedIn** and integrate it.
+3. You'll be redirected to log in. Complete the login.
+
+Once connected, this LinkedIn instance is available to use for event attendee scraping.
+
+---
+
+### **Scraping Event Attendees**
+
+1. Find the LinkedIn Event you want (and make sure you're registered/attending it).
+2. Copy the event's URL.
+3. In Bitscale, go to **New Grid** and select **Find Attendees of an Event**.
+4. Select the LinkedIn account you connected earlier.
+5. Paste the event URL.
+6. Set the **number of attendees** to import (for example, 100).
+7. Click **Import**.
+
+The pull takes a couple of minutes to process. Once it's done, you'll have attendees in your grid with:
+
+- First name
+- Last name
+- Headline
+- LinkedIn URL
+
+Other data points generally aren't available directly from the event itself.
+
+---
+
+### **Enriching Attendees**
+
+Since the LinkedIn URL is one of the most important key parameters for most enrichments on Bitscale, use it to build out context on each attendee:
+
+1. Go to **Enrichments** and search for **Enrich Person**.
+2. Map it to the **LinkedIn URL** column and save.
+3. Run it on the first 10 rows to check the output, then run it for the entire column.
+
+This gives you a fully contextualized profile for each attendee, headline, industry, current employer, and more, which you can use to:
+
+- build a GPT-based scoring layer on top of the enriched fields
+- pull out specific values (headline, industry, current employer) as their own columns
+- enrich the attendee's **employer's LinkedIn page** to see how many people work there, for extra account context
+
+---
+
+### **Summary**
+
+**Find Attendees of an Event** turns a LinkedIn Event into a sourced list of self-selected, in-market people. Connect your LinkedIn account, make sure you're attending the event, pull the attendee list, and enrich from there using the LinkedIn URL as your anchor. This is an enterprise, on-demand feature, reach out to the team to get it turned on.
+
+If you have questions, reach out to the Bitscale team on the community channel.

--- a/ingredients/tutorial-export-to-grid.mdx
+++ b/ingredients/tutorial-export-to-grid.mdx
@@ -1,0 +1,58 @@
+---
+title: "Exporting Data Between Grids (Export Leads & Export to Grid)"
+description: "Learn how to push list-based enrichment results (Export Leads) or a single row's data (Export to Grid) from one grid into another, including how to build a master grid that stays deduplicated across all your workflows."
+---
+
+### Overview
+
+<iframe width="100%" style={{aspectRatio: "16/9"}} src="https://www.youtube.com/embed/xW-UNTVSLz4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+List building on Bitscale almost always ends up needing two levels: an **account-level grid** (companies, with account-level enrichments) and a **contact-level grid** (the people you pulled from those accounts, along with the account context carried over). Bitscale has two related tools for moving data between grids like this, depending on whether you're exporting a list or a single row. This is also covered briefly in [Workbooks on Bitscale](/ingredients/workbooks); this page goes deeper on the two export options themselves.
+
+---
+
+### **Export Leads: pushing a list-based result into a new grid**
+
+Some enrichments return a **list** in a single cell, for example, **Find People from Company** returns multiple contacts for one company. Any time Bitscale returns a list-based response like this, you'll find an **Export Leads** button next to that profile/list section, whether it's a list of people, a list of a person's past experiences, or any other list-shaped result.
+
+**When to use it:** whenever you have a list-based response and want each item in that list to become its own row in another grid.
+
+**How it works:**
+
+1. Open the enrichment that returned the list (for example, **Find People from Company**).
+2. Click **Export Leads** next to the list.
+3. Choose to either:
+   - push into an **existing grid**, or
+   - **create a new grid**
+4. Optionally, choose which of your **current grid's columns** (account-level data you've already enriched, like industry) should be carried over and maintained against every exported contact.
+5. Save. The exported grid is automatically added to your **workbook**, alongside the grid you exported from.
+6. The setup itself doesn't move any data yet. **Run the column** to actually push rows into the new grid. If you have automation set up, new entries will flow through automatically going forward.
+
+Once contacts land in the second grid, you'll typically find the email/phone waterfall columns already available there, ready to run (or set to auto-run) for each new contact.
+
+---
+
+### **Export to Grid: pushing a single row's data**
+
+Sometimes you don't have a list response at all, you just want to send the data from the **current row** into another grid, one row in, one row out. Since there's no list, there's no Export Leads button to use here.
+
+The most common use case for this is a **master grid**: a single, deduplicated grid that every other workflow grid checks against (and pushes into) before enriching a contact, so you don't spend credits re-enriching someone you've already processed elsewhere.
+
+**How it works:**
+
+1. Go to **Enrichments → Data to Grid** and select **Export to Grid**.
+2. This is effectively the same underlying enrichment as Export Leads, the difference is you leave the **list field empty**, since there's no list to reference.
+3. Select which **columns** from the current row you want to push (for example, name, email, location).
+4. Save, then run it (for example, on the first 10 rows) to push those single rows into the destination grid.
+
+Once rows land in the destination grid, you can add any of the pushed fields as columns there and continue working with them.
+
+---
+
+### **Summary**
+
+- Use **Export Leads** when an enrichment gives you a **list** and you want each item exploded into its own row in another grid (for example, account → contacts).
+- Use **Export to Grid** (via Data to Grid) when you want to send the **current row's** data into another grid, one row at a time, most commonly to keep a **master grid** of everything you've already enriched.
+- Both tools link the source and destination grids into the same **workbook**, so you can navigate between them easily.
+
+If you have questions about setting this up, reach out to the Bitscale team on the support channel.

--- a/ingredients/workbooks.mdx
+++ b/ingredients/workbooks.mdx
@@ -44,4 +44,8 @@ This improves data traceability and reduces clutter—especially when you're wor
 
 ---
 
+For a deeper walkthrough of exporting list-based results (Export Leads) or single rows (Export to Grid), including how to set up a deduplicated master grid, see [Exporting Data Between Grids](/ingredients/tutorial-export-to-grid).
+
+---
+
 Need help setting up your workflow? Ping us anytime on the Bitscale Slack community—we’re always happy to help.


### PR DESCRIPTION
- ingredients/source-linkedin-event-attendees.mdx: new List Building source, scraping LinkedIn Event attendees via a connected LinkedIn account (enterprise, on-demand feature)
- ingredients/tutorial-export-to-grid.mdx: new Feature Walkthrough covering Export Leads (list-based export) and Export to Grid / Data to Grid (single-row export), including the master-grid pattern
- ingredients/workbooks.mdx: cross-linked to the new export tutorial